### PR TITLE
Update archpack_settings.py to biicode 3.3

### DIFF
--- a/archlinux/archpack_settings.py
+++ b/archlinux/archpack_settings.py
@@ -6,7 +6,7 @@
 #
 
 def settings():
-	return { "version": "3.0",
+	return { "version": "3.3",
 			 "release_number": "1",
 			 "arch_deps": ["cmake>=3.0.2", 
 			                "zlib", 


### PR DESCRIPTION
AUR PKGBUILD is outdated, after installing and running
`$ bii user <username>`
there is an error message indicating there is a newer version available. This PR just update the version number, I tested locally and it worked.
